### PR TITLE
Finished Last of Required Features and several bugs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,9 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.WRK"
         tools:targetApi="31">
+        <activity
+            android:name=".TrackerActivity"
+            android:exported="false" />
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"

--- a/app/src/main/java/com/example/wrk/CreateAdapter.java
+++ b/app/src/main/java/com/example/wrk/CreateAdapter.java
@@ -99,6 +99,14 @@ public class CreateAdapter extends RecyclerView.Adapter<CreateAdapter.ViewHolder
                     mContext.startActivity(i);
                 }
             });
+            ibStart.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    Intent i = new Intent(mContext, TrackerActivity.class);
+                    i.putExtra("template", Parcels.wrap(template));
+                    mContext.startActivity(i);
+                }
+            });
         }
     }
 

--- a/app/src/main/java/com/example/wrk/ScratchCreateActivity.java
+++ b/app/src/main/java/com/example/wrk/ScratchCreateActivity.java
@@ -11,6 +11,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -19,9 +20,12 @@ import android.widget.Toast;
 
 import com.example.wrk.models.Exercise;
 import com.example.wrk.models.WorkoutComponent;
+import com.example.wrk.models.WorkoutPerformed;
 import com.example.wrk.models.WorkoutTemplate;
+import com.parse.FindCallback;
 import com.parse.ParseException;
 import com.parse.ParseQuery;
+import com.parse.ParseUser;
 import com.parse.SaveCallback;
 
 import org.json.JSONArray;
@@ -29,6 +33,7 @@ import org.json.JSONException;
 import org.parceler.Parcels;
 
 import java.util.ArrayList;
+import java.util.List;
 
 // activity is used for creating a workout from scratch
 public class ScratchCreateActivity extends AppCompatActivity {
@@ -40,6 +45,7 @@ public class ScratchCreateActivity extends AppCompatActivity {
     RecyclerView rvComponents;
     ScratchCreateAdapter adapter;
     WorkoutTemplate workoutTemplate;
+    List<WorkoutPerformed> workoutsPerformed;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -52,8 +58,10 @@ public class ScratchCreateActivity extends AppCompatActivity {
         btnSave = findViewById(R.id.btnSave);
         rvComponents = findViewById(R.id.rvCreateComponents);
         mComponents = new ArrayList<>();
+        workoutsPerformed = new ArrayList<>();
 
-        workoutTemplate = (WorkoutTemplate) Parcels.unwrap(getIntent().getParcelableExtra("template"));     // receive existing template after edit button clicked
+
+        workoutTemplate = Parcels.unwrap(getIntent().getParcelableExtra("template"));     // receive existing template after edit button clicked
         if (workoutTemplate != null) { // if user clicks to edit existing workout, template will not be null
             try {
                 queryComponents(workoutTemplate);
@@ -78,6 +86,7 @@ public class ScratchCreateActivity extends AppCompatActivity {
             // Create an alert dialog to confirm deletion
             @Override
             public void onClick(View v) {
+                queryWorkouts();
                 AlertDialog.Builder builder = new AlertDialog.Builder(ScratchCreateActivity.this);
                 AlertDialog dialog;
                 builder.setTitle("Delete Template");
@@ -87,6 +96,13 @@ public class ScratchCreateActivity extends AppCompatActivity {
                     public void onClick(DialogInterface dialog, int which) {
                         if (workoutTemplate != null) {
                             try {
+                                // cannot delete template if others have posted with this workout
+                                for (int i = 0; i < workoutsPerformed.size(); i++) {
+                                    if (workoutsPerformed.get(i).getWorkout().getObjectId().equals(workoutTemplate.getObjectId())) {
+                                        Toast.makeText(ScratchCreateActivity.this, "Deleting this template will interfere with other's posts.", Toast.LENGTH_SHORT).show();
+                                        return;
+                                    }
+                                }
                                 workoutTemplate.delete();       // remove template from database
                             } catch (ParseException e) {
                                 e.printStackTrace();
@@ -149,7 +165,7 @@ public class ScratchCreateActivity extends AppCompatActivity {
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         if (requestCode == 1) {
             if (resultCode == RESULT_OK) {
-                Exercise exercise = (Exercise) data.getParcelableExtra("exercise");
+                Exercise exercise = data.getParcelableExtra("exercise");
                 WorkoutComponent component = new WorkoutComponent();
                 component.setExercise(exercise);
                 component.setSets(1);
@@ -201,5 +217,29 @@ public class ScratchCreateActivity extends AppCompatActivity {
             componentQuery.include(WorkoutComponent.KEY_SETS);
             mComponents.addAll(componentQuery.find());  // add objects to list
         }
+    }
+
+    private void queryWorkouts() {
+        ParseQuery<WorkoutPerformed> performedQuery = ParseQuery.getQuery(WorkoutPerformed.class);
+        // includes specified data
+        performedQuery.include(WorkoutPerformed.KEY_USER);
+        performedQuery.include(WorkoutPerformed.KEY_WORKOUT);
+        // limits number of items to generate
+        performedQuery.setLimit(6);
+        // order by creation date (newest first)
+        performedQuery.addDescendingOrder("createdAt");
+        // async call for posts
+        performedQuery.findInBackground(new FindCallback<WorkoutPerformed>() {
+            @Override
+            public void done(List<WorkoutPerformed> workouts, ParseException e) {
+                if (e != null) {
+                    Log.e("ScratchCreateActivity", "Error with fetching workouts. ", e);
+                    return;
+                }
+                // save received posts to list and notify adapter of new data
+                workoutsPerformed.addAll(workouts);
+                adapter.notifyDataSetChanged();
+            }
+        });
     }
 }

--- a/app/src/main/java/com/example/wrk/ScratchCreateActivity.java
+++ b/app/src/main/java/com/example/wrk/ScratchCreateActivity.java
@@ -60,7 +60,6 @@ public class ScratchCreateActivity extends AppCompatActivity {
         mComponents = new ArrayList<>();
         workoutsPerformed = new ArrayList<>();
 
-
         workoutTemplate = Parcels.unwrap(getIntent().getParcelableExtra("template"));     // receive existing template after edit button clicked
         if (workoutTemplate != null) { // if user clicks to edit existing workout, template will not be null
             try {
@@ -220,12 +219,11 @@ public class ScratchCreateActivity extends AppCompatActivity {
     }
 
     private void queryWorkouts() {
+        workoutsPerformed.clear();
         ParseQuery<WorkoutPerformed> performedQuery = ParseQuery.getQuery(WorkoutPerformed.class);
         // includes specified data
         performedQuery.include(WorkoutPerformed.KEY_USER);
         performedQuery.include(WorkoutPerformed.KEY_WORKOUT);
-        // limits number of items to generate
-        performedQuery.setLimit(6);
         // order by creation date (newest first)
         performedQuery.addDescendingOrder("createdAt");
         // async call for posts
@@ -236,9 +234,8 @@ public class ScratchCreateActivity extends AppCompatActivity {
                     Log.e("ScratchCreateActivity", "Error with fetching workouts. ", e);
                     return;
                 }
-                // save received posts to list and notify adapter of new data
+                // save received posts to list
                 workoutsPerformed.addAll(workouts);
-                adapter.notifyDataSetChanged();
             }
         });
     }

--- a/app/src/main/java/com/example/wrk/ScratchCreateActivity.java
+++ b/app/src/main/java/com/example/wrk/ScratchCreateActivity.java
@@ -29,7 +29,6 @@ import org.json.JSONException;
 import org.parceler.Parcels;
 
 import java.util.ArrayList;
-import java.util.List;
 
 // activity is used for creating a workout from scratch
 public class ScratchCreateActivity extends AppCompatActivity {

--- a/app/src/main/java/com/example/wrk/ScratchCreateAdapter.java
+++ b/app/src/main/java/com/example/wrk/ScratchCreateAdapter.java
@@ -85,7 +85,7 @@ public class ScratchCreateAdapter extends RecyclerView.Adapter<ScratchCreateAdap
                 tbrow.addView(tvPrevWeight);
                 // weight column
                 etWeight = new EditText(tableContext);
-                etWeight.setInputType(InputType.TYPE_NUMBER_FLAG_DECIMAL);
+                etWeight.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
                 etWeight.setHint(tvPrevWeight.getText());       // set a placeholder with previous weight
                 // update weight for database based on what user inputs
                 etWeight.addTextChangedListener(new TextWatcher() {
@@ -95,7 +95,13 @@ public class ScratchCreateAdapter extends RecyclerView.Adapter<ScratchCreateAdap
                     public void onTextChanged(CharSequence s, int start, int before, int count) {}
                     @Override
                     public void afterTextChanged(Editable s) {
-                        component.setWeight(Double.parseDouble(s.toString()));
+                        try {
+                            component.setWeight(Double.parseDouble(s.toString()));
+                        }
+                        catch (NumberFormatException n) {
+                            etWeight.setText("0.0");
+                        }
+
                     }
                 });
                 tbrow.addView(etWeight);
@@ -134,7 +140,7 @@ public class ScratchCreateAdapter extends RecyclerView.Adapter<ScratchCreateAdap
                     tbrow.addView(tvPrevAmount);
                     // weight column
                     etWeight = new EditText(tableContext);
-                    etWeight.setInputType(InputType.TYPE_NUMBER_FLAG_DECIMAL);
+                    etWeight.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
                     etWeight.setText(String.valueOf(component.getWeight()));        // set a placeholder with weight from existing sets
                     tbrow.addView(etWeight);
                     // reps column

--- a/app/src/main/java/com/example/wrk/TrackerActivity.java
+++ b/app/src/main/java/com/example/wrk/TrackerActivity.java
@@ -1,0 +1,157 @@
+package com.example.wrk;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ImageButton;
+import android.widget.Toast;
+
+import com.example.wrk.fragments.CreateFragment;
+import com.example.wrk.models.Exercise;
+import com.example.wrk.models.WorkoutComponent;
+import com.example.wrk.models.WorkoutPerformed;
+import com.example.wrk.models.WorkoutTemplate;
+import com.parse.ParseException;
+import com.parse.ParseQuery;
+import com.parse.ParseUser;
+import com.parse.SaveCallback;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.parceler.Parcels;
+
+import java.util.ArrayList;
+
+public class TrackerActivity extends AppCompatActivity {
+    EditText etTrackerWorkoutTitle;
+    Button btnFinish;
+    ImageButton ibADDExercise;
+    WorkoutTemplate workoutTemplate;
+    RecyclerView rvTrackerComponents;
+    ScratchCreateAdapter adapter;
+    ArrayList<WorkoutComponent> mComponents;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_tracker);
+
+        etTrackerWorkoutTitle = findViewById(R.id.etTrackerWorkoutTitle);
+        btnFinish = findViewById(R.id.btnFinish);
+        ibADDExercise = findViewById(R.id.ibADDExercise);
+        rvTrackerComponents = findViewById(R.id.rvTrackerComponents);
+
+        workoutTemplate = Parcels.unwrap(getIntent().getParcelableExtra("template"));
+        try {
+            queryComponents(workoutTemplate);
+        } catch (ParseException | JSONException e) {
+            e.printStackTrace();
+        }
+        etTrackerWorkoutTitle.setText(workoutTemplate.getTitle());
+
+        ibADDExercise.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent i = new Intent(TrackerActivity.this, ExerciseListActivity.class);
+                startActivityForResult(i, 1);
+            }
+        });
+
+        btnFinish.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+
+                String title = etTrackerWorkoutTitle.getText().toString();
+                if (title != null && !title.isEmpty()) {
+                    if (mComponents.size() != 0) {
+                        try {
+                            updateTemplate(workoutTemplate, title, mComponents);  // update template in database
+                        } catch (ParseException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    else {
+                        Toast.makeText(TrackerActivity.this, "No exercises found.", Toast.LENGTH_SHORT).show();
+                    }
+                }
+                else {
+                    Toast.makeText(TrackerActivity.this, "Please enter a title.", Toast.LENGTH_SHORT).show();
+                }
+                publishWorkout();           // save to database and post to feed
+                Intent i = new Intent(TrackerActivity.this, MainActivity.class);
+                startActivity(i);
+            }
+        });
+
+        adapter = new ScratchCreateAdapter(this, mComponents);
+        rvTrackerComponents.setLayoutManager(new LinearLayoutManager(this));
+        rvTrackerComponents.setAdapter(adapter);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        if (requestCode == 1) {
+            if (resultCode == RESULT_OK) {
+                Exercise exercise = (Exercise) data.getParcelableExtra("exercise");
+                WorkoutComponent component = new WorkoutComponent();
+                component.setExercise(exercise);
+                component.setSets(1);
+                mComponents.add(component);
+                adapter.notifyItemInserted(mComponents.size());
+            }
+        }
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+    private void updateTemplate(WorkoutTemplate workoutTemplate, String title, ArrayList<WorkoutComponent> components) throws ParseException {
+        workoutTemplate.setTitle(title);                // for if title has been changed
+        workoutTemplate.setComponents(components);      // for if components changed
+        workoutTemplate.saveInBackground(new SaveCallback() {
+            @Override
+            public void done(ParseException e) {
+                if (e != null) {
+                    Toast.makeText(TrackerActivity.this, "Error while updating template", Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
+    }
+
+    private void publishWorkout() {
+        WorkoutPerformed workoutPerformed = new WorkoutPerformed();
+        workoutPerformed.setWorkout(workoutTemplate);
+        workoutPerformed.setUser(ParseUser.getCurrentUser());
+        workoutPerformed.setStatus(true);       // visibility to public
+        workoutPerformed.saveInBackground(new SaveCallback() {
+            @Override
+            public void done(ParseException e) {
+                if (e != null) {
+                    Toast.makeText(TrackerActivity.this, "Error while publishing to feed.", Toast.LENGTH_SHORT).show();
+                    return;
+                }
+            }
+        });
+    }
+
+    private void queryComponents(WorkoutTemplate template) throws ParseException, JSONException {
+        mComponents = new ArrayList<>();     // initialize empty list each time a query is called
+        JSONArray componentArray = template.getComponents();
+        ParseQuery<WorkoutComponent> componentQuery = ParseQuery.getQuery(WorkoutComponent.class);
+        for (int i = 0; i < componentArray.length(); i++) {
+            // grab ID to ensure only those with same id get shown
+            String id = componentArray.getJSONObject(i).getString("objectId");
+            // add filter to grab only components in the specific workout
+            componentQuery.whereEqualTo(WorkoutComponent.KEY_OBJECT_ID, id);
+            componentQuery.include(WorkoutComponent.KEY_EXERCISE);
+            componentQuery.include(WorkoutComponent.KEY_REPS);
+            componentQuery.include(WorkoutComponent.KEY_SETS);
+            mComponents.addAll(componentQuery.find());  // add objects to list
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_tracker.xml
+++ b/app/src/main/res/layout/activity_tracker.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".TrackerActivity">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvTrackerComponents"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="2dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="2dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/etTrackerWorkoutTitle" />
+
+    <EditText
+        android:id="@+id/etTrackerWorkoutTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:ems="10"
+        android:hint="Workout Title"
+        android:inputType="textPersonName|textCapCharacters"
+        android:minHeight="48dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageButton
+        android:id="@+id/ibADDExercise"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:backgroundTint="#FFFFFF"
+        app:layout_constraintEnd_toStartOf="@+id/btnFinish"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/plus" />
+
+    <Button
+        android:id="@+id/btnFinish"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Finish"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/secrets.xml
+++ b/app/src/main/res/values/secrets.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="MAPS_API_KEY">AIzaSyCQUqPomLLpCqZPC3GuX7cl6XN12YXbj0k</string>
-</resources>


### PR DESCRIPTION
- Implemented the TrackerActivity that allows users to publish their workout to the feed once they are done with it.
  - Used the same adapter that is used within the ScratchCreateActivity
- BUG FIXES:
  - Deleting Template causes crash if someone else has completed the workout
    - Fixed with error handling to ensure that a template cannot be deleted if someone else has completed it for a post.
  - Duplicate table shows in background when the delete button clicked
    - Deleted the adapter notify within the queryWorkouts function as nothing is changing within the adapter.
  - Builder crash when editing weight and backspace too many times
    - App would crash if a user clicks backspace when editing the weight to the point that it would clear the field. In order to fix this, catch the error and reset the weight to 0.0 so the user can understand that the field is empty.

https://user-images.githubusercontent.com/83436163/176514696-add9ddad-221a-472a-a148-0f9c4b6500b3.mov

