### PR TITLE
Implement double tap feature to save templates

### DIFF
--- a/app/src/main/java/com/example/wrk/OnDoubleTapListener.java
+++ b/app/src/main/java/com/example/wrk/OnDoubleTapListener.java
@@ -1,0 +1,34 @@
+package com.example.wrk;
+
+import android.content.Context;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+import android.view.View;
+
+public class OnDoubleTapListener implements View.OnTouchListener {
+    private GestureDetector gestureDetector;
+
+    public OnDoubleTapListener(Context context) {
+        gestureDetector = new GestureDetector(context, new GestureListener());
+    }
+
+    public boolean onTouch(final View view, final MotionEvent motionEvent) {
+        return gestureDetector.onTouchEvent(motionEvent);
+    }
+
+    private final class GestureListener extends GestureDetector.SimpleOnGestureListener {
+        @Override
+        public boolean onDown(MotionEvent e) {
+            return true;
+        }
+        @Override
+        public boolean onDoubleTap(MotionEvent e) {
+            OnDoubleTapListener.this.onDoubleTap(e);
+            return super.onDoubleTap(e);
+        }
+    }
+
+    public void onDoubleTap(MotionEvent e) {
+        // To be overridden when implementing listener
+    }
+}

--- a/app/src/main/java/com/example/wrk/WorkoutsAdapter.java
+++ b/app/src/main/java/com/example/wrk/WorkoutsAdapter.java
@@ -1,16 +1,20 @@
 package com.example.wrk;
 
 import android.content.Context;
+import android.os.Build;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
@@ -122,6 +126,22 @@ public class WorkoutsAdapter extends RecyclerView.Adapter<WorkoutsAdapter.ViewHo
 
                 tlWorkouts.addView(tbrow);      // link row to the tablelayout
             }
+            // double tap action to save a template
+            tlWorkouts.setOnTouchListener(new OnDoubleTapListener(mContext) {
+                @RequiresApi(api = Build.VERSION_CODES.N)
+                @Override
+                public void onDoubleTap(MotionEvent e) {
+                    // save template to users account if not already saved
+                    WorkoutTemplate tappedTemplate = workoutPerformed.getWorkout();
+                    if (!tappedTemplate.isSavedByCurrentUser()) {
+                        tappedTemplate.saveUserTemplate();
+                        Toast.makeText(mContext, "Saved " + tappedTemplate.getTitle() + " to your templates.", Toast.LENGTH_SHORT).show();
+                    }
+                    else {
+                        Toast.makeText(mContext, "You already have this template saved.", Toast.LENGTH_SHORT).show();
+                    }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Summary:
- Created a class specifically for a double tap listener that implements the OnTouch listener
- Allows a user to double tap the title of a workout in the FeedFragment to save the template to their profile if they have not already done so

Test Plan:
- Double tap template that is not currently in user's saved templates
  - Toasts to let user know that it saves template to user's profile
- Double tap template that is already in user's saved templates
  - Toasts to let user know that template is already saved, then does not add another

Before: User cannot interact with the FeedFragment
After: User can double tap any individual workout in the feed to save it to their templates.

https://user-images.githubusercontent.com/83436163/177399076-375d6719-1383-4810-92a0-9d115292273a.mov
