### PR TITLE
Finished calculations for user's daily streak

### DIFF
--- a/app/src/main/java/com/example/wrk/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/example/wrk/fragments/ProfileFragment.java
@@ -33,7 +33,10 @@ import com.parse.ParseFile;
 import com.parse.ParseQuery;
 import com.parse.ParseUser;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 public class ProfileFragment extends Fragment {
@@ -103,6 +106,7 @@ public class ProfileFragment extends Fragment {
         tvProfileUsername = view.findViewById(R.id.tvProfileUsername);
         tvProfileUsername.setText(user.getUsername());
 
+        updateStreak(user);     // check each time someone visits a profile
         tvDailyStreak = view.findViewById(R.id.tvDailyStreak);
         tvDailyStreak.setText(String.valueOf(user.getInt("streak")));
 
@@ -157,5 +161,37 @@ public class ProfileFragment extends Fragment {
                 adapter.notifyDataSetChanged();
             }
         });
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    protected void updateStreak(ParseUser user) {
+        Date lastWorkout = user.getDate("lastWorkout");
+        int streak = user.getInt("streak");     // current daily streak
+        int dayDifference = 0;
+        int yearDifference = 0;
+        int currentDayOfYear;
+        int recentWorkoutDayOfYear;
+
+        if (lastWorkout != null) {
+            // calculate difference in days since last workout
+            // this is to allow for more than 24 hrs since workout as long as date is 1 day apart
+            LocalDate today = LocalDate.now();
+            currentDayOfYear = today.getDayOfYear();
+
+            LocalDate recentWorkout = lastWorkout.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+            recentWorkoutDayOfYear = recentWorkout.getDayOfYear();
+
+            dayDifference = currentDayOfYear - recentWorkoutDayOfYear;      // will be negative if two different years
+            yearDifference = today.getYear() - recentWorkout.getYear();     // to calculate if years have gone by since last workout
+        }
+
+        // reset streak to 0 if more than 1 day has past since working out
+        if (lastWorkout == null || dayDifference > 1 || (dayDifference <= 0 && yearDifference > 0) ) {
+            streak = 0;     // reset to 0
+        }
+
+        // save to database
+        user.put("streak", streak);
+        user.saveInBackground();
     }
 }


### PR DESCRIPTION
Summary
- Uses the DateTime library to get the current day of the year and the most recent workout day of the year
- Once it gathers this information, it performs a calculation to check whether one calendar day has past (to allow for more than 24 hours between workouts)
  - This is necessary to prevent resetting their streak in case someone works out at 8am one day and 5pm the next day.
  - Also accounts for working out on new year's day/eve and a leap year

Test Plan
- Check a profile to make sure that it runs an up to date calculation for a daily streak: Will reset to 0 if more than a day has gone by since a previous workout. Will not change if there is still time within the day
- Publish a workout to check that it properly increments a streak: 
- Check that doing multiple workouts in a day doesn't increment the streak

Demo
Miriam: July 3, streak 0 (multiple days since last workout -> increment 1 when publish)

https://user-images.githubusercontent.com/83436163/177841261-2ab096c6-597f-4350-9f43-a16b66a37769.mov

JC Garza: July 6, streak 2 (1 day since last workout -> increment streak to 3 after publishing new workout)

https://user-images.githubusercontent.com/83436163/177841669-2f9ba0f4-cdf8-4388-9df7-714f3bd37ee3.mov

Steven: July 5, streak 1 (multiple days since last workout -> reset to 0 when view profile)

https://user-images.githubusercontent.com/83436163/177841951-d06d617d-4f95-4d5e-a067-ae3c6e8aea8e.mov

Joe: July 7, streak 1 (0 days since last workout -> still streak of 1 after publishing another workout)

https://user-images.githubusercontent.com/83436163/177842199-710bb621-b3b4-41d8-9498-a0f72c9c7c7d.mov

 