### PR TITLE
 Implement recent and popular feed algorithm

### DIFF
--- a/app/src/main/java/com/example/wrk/ParseApplication.java
+++ b/app/src/main/java/com/example/wrk/ParseApplication.java
@@ -20,8 +20,8 @@ public class ParseApplication extends Application {
         ParseObject.registerSubclass(WorkoutTemplate.class);
         ParseObject.registerSubclass(WorkoutPerformed.class);
         Parse.initialize(new Parse.Configuration.Builder(this)
-                .applicationId("UvPVrtPTjTAssjhNb38M4frI3TAB4W8sbNtCVFzl")
-                .clientKey("2hAd20HEgVCNPptNkuCnRrWDDMSkk1D77llezJ5h")
+                .applicationId(getString(R.string.APPLICATION_ID))
+                .clientKey(getString(R.string.CLIENT_KEY))
                 .server("https://parseapi.back4app.com")
                 .build()
         );

--- a/app/src/main/java/com/example/wrk/RegisterActivity.java
+++ b/app/src/main/java/com/example/wrk/RegisterActivity.java
@@ -14,6 +14,9 @@ import com.parse.ParseException;
 import com.parse.ParseUser;
 import com.parse.SignUpCallback;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class RegisterActivity extends AppCompatActivity {
     private EditText etRegName;
     private EditText etRegUsername;
@@ -53,6 +56,11 @@ public class RegisterActivity extends AppCompatActivity {
                         finish();
                     }
                 });
+                // assign following list with new user so they will see their posts at top of feed when created
+                List<ParseUser> list = new ArrayList<>();
+                list.add(user);
+                user.put("following", list);
+                user.saveInBackground();
             }
         });
     }

--- a/app/src/main/java/com/example/wrk/fragments/CreateFragment.java
+++ b/app/src/main/java/com/example/wrk/fragments/CreateFragment.java
@@ -121,8 +121,6 @@ public class CreateFragment extends Fragment {
         templatesQuery.include(WorkoutTemplate.KEY_TITLE);
         templatesQuery.include(WorkoutTemplate.KEY_COMPONENTS);
         templatesQuery.include(WorkoutTemplate.KEY_SAVED_BY);
-        // limits number of items to generate
-        templatesQuery.setLimit(6);
         // order by creation date (newest first)
         templatesQuery.addDescendingOrder("createdAt");
         // async call for posts

--- a/app/src/main/java/com/example/wrk/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/wrk/fragments/FeedFragment.java
@@ -1,9 +1,11 @@
 package com.example.wrk.fragments;
 
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -17,11 +19,17 @@ import com.example.wrk.MainActivity;
 import com.example.wrk.R;
 import com.example.wrk.models.WorkoutPerformed;
 import com.example.wrk.WorkoutsAdapter;
+import com.example.wrk.models.WorkoutTemplate;
 import com.parse.FindCallback;
 import com.parse.ParseException;
 import com.parse.ParseQuery;
+import com.parse.ParseUser;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 // FeedFragment is what is shown when the home logo is tapped within the app
@@ -30,6 +38,9 @@ public class FeedFragment extends Fragment {
 
     private RecyclerView rvWorkouts;
     protected List<WorkoutPerformed> workoutsPerformed;
+    protected List<WorkoutPerformed> recentFollowedWorkouts;
+    protected List<WorkoutTemplate> popularTemplates;
+    protected List<WorkoutPerformed> mostPopularWorkouts;
     protected  WorkoutsAdapter adapter;
 
     public FeedFragment() {
@@ -48,6 +59,7 @@ public class FeedFragment extends Fragment {
         return inflater.inflate(R.layout.fragment_feed, container, false);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.O)
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
@@ -58,30 +70,122 @@ public class FeedFragment extends Fragment {
         adapter = new WorkoutsAdapter((MainActivity) getContext(), workoutsPerformed);
         rvWorkouts.setLayoutManager(layoutManager);
         rvWorkouts.setAdapter(adapter);
-        queryWorkouts();
+        try {
+            queryRecentFollowedWorkouts();
+        } catch (ParseException e) {
+            Log.e(TAG, "ERROR FETCHING RECENT WORKOUTS. ", e);
+        }
+        try {
+            queryPopularWorkouts();
+        } catch (ParseException e) {
+            Log.e(TAG, "ERROR FETCHING POPULAR WORKOUTS. ", e);
+        }
+        try {
+            queryWorkouts();
+        } catch (ParseException e) {
+            Log.e(TAG, "ERROR FETCHING COMMUNITY WORKOUTS. ", e);
+        }
+        adapter.notifyDataSetChanged();
     }
 
-    protected void queryWorkouts() {
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    protected void queryRecentFollowedWorkouts() throws ParseException {
+        // query most recent posts within past two days
+        final long DAYS_COUNT = 2;
+        LocalDate today = LocalDate.now();
+
+        // get week before current date
+        LocalDate daysAgoDate = today.minusDays(DAYS_COUNT);
+
+        ParseQuery<WorkoutPerformed> performedQuery = ParseQuery.getQuery(WorkoutPerformed.class);
+        performedQuery.include(WorkoutPerformed.KEY_USER);
+        performedQuery.include(WorkoutPerformed.KEY_WORKOUT);
+        performedQuery.addDescendingOrder(WorkoutPerformed.KEY_CREATED_AT);
+        performedQuery.setLimit(5);
+        // specify workouts
+        performedQuery.whereContainedIn(WorkoutPerformed.KEY_USER, ParseUser.getCurrentUser().getList("following"));
+
+        List<WorkoutPerformed> list = new ArrayList<>();
+        recentFollowedWorkouts = new ArrayList<>();
+        list.addAll(performedQuery.find());
+        for (int i = 0; i < list.size(); i++) {
+            LocalDate postDate = list.get(i)
+                    .getCreatedAt().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+            // only add the posts within the past 2 days
+            if (postDate.isAfter(daysAgoDate)) {
+                recentFollowedWorkouts.add(list.get(i));
+            }
+        }
+        workoutsPerformed.addAll(recentFollowedWorkouts);
+    }
+
+    protected void queryPopularWorkouts() throws ParseException {
+        ParseQuery<WorkoutTemplate> performedQuery = ParseQuery.getQuery(WorkoutTemplate.class);
+        // includes specified data
+        performedQuery.include(WorkoutTemplate.KEY_TITLE);
+        performedQuery.include(WorkoutTemplate.KEY_COMPONENTS);
+        performedQuery.addDescendingOrder(WorkoutTemplate.KEY_SAVED_BY);
+        List<WorkoutTemplate> allTemplates = new ArrayList<>();
+        allTemplates.addAll(performedQuery.find());
+
+        popularTemplates = new ArrayList<>();
+        mostPopularWorkouts = new ArrayList<>();
+
+        // compare amount of users that saved the templates
+        Comparator<WorkoutTemplate> workoutTemplateComparator = new Comparator<WorkoutTemplate>() {
+            @Override
+            public int compare(WorkoutTemplate t1, WorkoutTemplate t2) {
+                return Integer.compare(t1.getSavedBy().size(), t2.getSavedBy().size());
+            }
+        };
+        // sort templates by greatest to least in save count
+        Collections.sort(allTemplates, workoutTemplateComparator);
+        Collections.reverse(allTemplates);
+        // place up to top 3 templates into the popular ones
+        for (int i = 0; i < allTemplates.size(); i++) {
+            if (i == 3) {
+                break;
+            }
+            else {
+                popularTemplates.add(allTemplates.get(i));
+            }
+        }
+        ParseQuery<WorkoutPerformed> parseQuery = ParseQuery.getQuery(WorkoutPerformed.class);
+        parseQuery.include(WorkoutPerformed.KEY_USER);
+        parseQuery.include(WorkoutPerformed.KEY_WORKOUT);
+        // look for posts that are within the popular templates
+        parseQuery.whereContainedIn(WorkoutPerformed.KEY_WORKOUT, popularTemplates);
+        // newest first
+        parseQuery.addDescendingOrder(WorkoutPerformed.KEY_CREATED_AT);
+        mostPopularWorkouts.addAll(parseQuery.find());
+
+        // remove if template is the same as another post
+        for (int i = 0; i < mostPopularWorkouts.size(); i++) {
+            for (int j = i + 1; j < mostPopularWorkouts.size(); j++) {
+                if (mostPopularWorkouts.get(i).getWorkout().hasSameId(mostPopularWorkouts.get(j).getWorkout())) {
+                    mostPopularWorkouts.remove(j);
+                    j = i;
+                }
+            }
+        }
+        workoutsPerformed.addAll(mostPopularWorkouts);
+    }
+
+    // query community workouts, mix of older posts from friends and less popular templates
+    protected void queryWorkouts() throws ParseException {
         ParseQuery<WorkoutPerformed> performedQuery = ParseQuery.getQuery(WorkoutPerformed.class);
         // includes specified data
         performedQuery.include(WorkoutPerformed.KEY_USER);
         performedQuery.include(WorkoutPerformed.KEY_WORKOUT);
+        // to remove posts that have already been added
+        performedQuery.whereNotContainedIn(WorkoutPerformed.KEY_USER, recentFollowedWorkouts);
+        performedQuery.whereNotContainedIn(WorkoutPerformed.KEY_WORKOUT, mostPopularWorkouts);
         // limits number of items to generate
-        performedQuery.setLimit(5);
+        performedQuery.setLimit(4);
         // order by creation date (newest first)
         performedQuery.addDescendingOrder("createdAt");
         // async call for posts
-        performedQuery.findInBackground(new FindCallback<WorkoutPerformed>() {
-            @Override
-            public void done(List<WorkoutPerformed> workouts, ParseException e) {
-                if (e != null) {
-                    Log.e(TAG, "Error with fetching workouts. ", e);
-                    return;
-                }
-                // save received posts to list and notify adapter of new data
-                workoutsPerformed.addAll(workouts);
-                adapter.notifyDataSetChanged();
-            }
-        });
+        workoutsPerformed.addAll(performedQuery.find());
+        Log.d(TAG, "OTHER POSTS COUNT: " + performedQuery.find().size());
     }
 }

--- a/app/src/main/java/com/example/wrk/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/wrk/fragments/FeedFragment.java
@@ -39,6 +39,7 @@ public class FeedFragment extends Fragment {
     private RecyclerView rvWorkouts;
     protected List<WorkoutPerformed> workoutsPerformed;
     protected List<WorkoutPerformed> recentFollowedWorkouts;
+    protected List<ParseUser> recentFollowedUsers;
     protected List<WorkoutTemplate> popularTemplates;
     protected List<WorkoutPerformed> mostPopularWorkouts;
     protected  WorkoutsAdapter adapter;
@@ -102,11 +103,12 @@ public class FeedFragment extends Fragment {
         performedQuery.include(WorkoutPerformed.KEY_WORKOUT);
         performedQuery.addDescendingOrder(WorkoutPerformed.KEY_CREATED_AT);
         performedQuery.setLimit(5);
-        // specify workouts
+        // specify workouts from the user's following list
         performedQuery.whereContainedIn(WorkoutPerformed.KEY_USER, ParseUser.getCurrentUser().getList("following"));
 
         List<WorkoutPerformed> list = new ArrayList<>();
         recentFollowedWorkouts = new ArrayList<>();
+        recentFollowedUsers = new ArrayList<>();
         list.addAll(performedQuery.find());
         for (int i = 0; i < list.size(); i++) {
             LocalDate postDate = list.get(i)
@@ -114,6 +116,7 @@ public class FeedFragment extends Fragment {
             // only add the posts within the past 2 days
             if (postDate.isAfter(daysAgoDate)) {
                 recentFollowedWorkouts.add(list.get(i));
+                recentFollowedUsers.add(list.get(i).getUser());
             }
         }
         workoutsPerformed.addAll(recentFollowedWorkouts);
@@ -178,14 +181,13 @@ public class FeedFragment extends Fragment {
         performedQuery.include(WorkoutPerformed.KEY_USER);
         performedQuery.include(WorkoutPerformed.KEY_WORKOUT);
         // to remove posts that have already been added
-        performedQuery.whereNotContainedIn(WorkoutPerformed.KEY_USER, recentFollowedWorkouts);
-        performedQuery.whereNotContainedIn(WorkoutPerformed.KEY_WORKOUT, mostPopularWorkouts);
+        performedQuery.whereNotContainedIn(WorkoutPerformed.KEY_USER, recentFollowedUsers);
+        performedQuery.whereNotContainedIn(WorkoutPerformed.KEY_WORKOUT, popularTemplates);
         // limits number of items to generate
         performedQuery.setLimit(4);
         // order by creation date (newest first)
         performedQuery.addDescendingOrder("createdAt");
         // async call for posts
         workoutsPerformed.addAll(performedQuery.find());
-        Log.d(TAG, "OTHER POSTS COUNT: " + performedQuery.find().size());
     }
 }

--- a/app/src/main/java/com/example/wrk/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/wrk/fragments/FeedFragment.java
@@ -158,6 +158,8 @@ public class FeedFragment extends Fragment {
         parseQuery.include(WorkoutPerformed.KEY_WORKOUT);
         // look for posts that are within the popular templates
         parseQuery.whereContainedIn(WorkoutPerformed.KEY_WORKOUT, popularTemplates);
+        // remove any posts that already exists
+        parseQuery.whereNotContainedIn(WorkoutPerformed.KEY_USER, recentFollowedUsers); // in the case that user's followed recent posts are also popular
         // newest first
         parseQuery.addDescendingOrder(WorkoutPerformed.KEY_CREATED_AT);
         mostPopularWorkouts.addAll(parseQuery.find());

--- a/app/src/main/java/com/example/wrk/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/example/wrk/fragments/ProfileFragment.java
@@ -20,6 +20,7 @@ import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
@@ -33,6 +34,7 @@ import com.parse.ParseException;
 import com.parse.ParseFile;
 import com.parse.ParseQuery;
 import com.parse.ParseUser;
+import com.parse.SaveCallback;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -187,7 +189,14 @@ public class ProfileFragment extends Fragment {
         ParseUser currentUser = ParseUser.getCurrentUser();
         followingList.add(user);        // add user to currentUsers follow list
         currentUser.put("following", followingList);
-        currentUser.saveInBackground();
+        currentUser.saveInBackground(new SaveCallback() {
+            @Override
+            public void done(ParseException e) {
+                if (e != null) {
+                    Toast.makeText(mainActivity, "Error saving user.", Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
     }
 
     private boolean isFollowedByCurrentUser() {


### PR DESCRIPTION
Summary
- Implemented a unique algorithm for each user to populate their feed differently. Every user's feed is made up of the most recent workout posts from people they follow within the past two days. Then it highlights some recent posts from the most popular templates at the current time. Lastly, it shows posts from the rest of the community, including posts that weren't already shown in order of most recent.

Test Plan
As you can see in the screenshots I will attach, each user generates a different number of posts as each of them follow different people or none at all.

Test 1: User follows no one --> 0 recents, shows most popular templates next, then the rest of community
<img width="825" alt="M4D2_FeedAlgLog_0following" src="https://user-images.githubusercontent.com/83436163/178622996-26ea21ea-3254-4f4b-9906-f8bff3d42019.png">

Test 2: User follows multiple people --> Shows recents from user's within past two days, then top 3 most popular, then the rest of community
<img width="825" alt="M4D2_FeedAlgLog_multipleFollowing" src="https://user-images.githubusercontent.com/83436163/178623147-dc3eead2-9370-4b19-b597-2bcf1bfbc17d.png">

Test 3: Different User follows multiple people and just posted --> Shows recents from the followed (including the user's), then the most popular, then the rest of the community
<img width="825" alt="M4D2_FeedAlgLog_example3" src="https://user-images.githubusercontent.com/83436163/178623163-f4679c75-9b0d-4fd3-87c7-ad08c03efd1a.png">

Test 2 and 3 show that there are different number of recents to show that it works for different user's depending on who they follow. Currently for testing purposes, I have the community posts to be limited to 4 which is why you see that for all the tests.


Demo
The feed visually looks the same so I will not include a video of the feed at this time. Perhaps if I have time I can try to add something to help the user differentiate between the different sections of the feed