### PR TITLE
Implement percentage comparison to friends # of workouts in month

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/red"
-    android:clickable="true"
     tools:context=".LoginActivity">
 
     <TextView


### PR DESCRIPTION
Summary
- Calculates average for the number of friends' workouts in the current month
- Compares that number with signed in user's number of workouts in current month
- Calculates percent difference
- Displays next to profile the percent increase/decrease in comparison to their friends.

Test Plan
- Test on someone who follows 0 people: default value shows 0%
<img width="277" alt="M5D1_PercentageZero" src="https://user-images.githubusercontent.com/83436163/179604781-6d3fbb31-d356-44ca-9aea-8de41a6a4442.png">

- Test on someone who follows multiple people that have more workouts than them: shows specific message for less than their friends
<img width="277" alt="M5D1_PercentageLess" src="https://user-images.githubusercontent.com/83436163/179604692-979f6a10-6e5f-49b5-9c64-a4bd99bfa9a3.png">

<img width="277" alt="M5D1_PercentageLess2" src="https://user-images.githubusercontent.com/83436163/179604971-fea2cada-bc6c-4bf6-b593-e597f31ff459.png">

- Test on someone who follows multiple people that have less workouts than them: shows specific message for more than their friends

<img width="277" alt="M5D1_PercentageMore" src="https://user-images.githubusercontent.com/83436163/179604555-e516e840-199a-447c-a0d6-7df6b8bb2cb6.png">